### PR TITLE
add jumphost feature

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ import (
 
 // Config represents the configuration for the exporter
 type Config struct {
+	Jumphost  JumphostConfig  `yaml:"jumphost"`
 	Password  string          `yaml:"password"`
 	Targets   []string        `yaml:"targets,omitempty"`
 	Devices   []*DeviceConfig `yaml:"devices,omitempty"`
@@ -18,11 +19,19 @@ type Config struct {
 
 // DeviceConfig is the config representation of 1 device
 type DeviceConfig struct {
+	Jumphost JumphostConfig `yaml:"jumphost"`
 	Host     string         `yaml:"host"`
 	Username string         `yaml:"username,omitempty"`
 	Password string         `yaml:"password,omitempty"`
 	KeyFile  string         `yaml:"key_file,omitempty"`
 	Features *FeatureConfig `yaml:"features,omitempty"`
+}
+
+type JumphostConfig struct {
+	Host     string `yaml:"host"`
+	Username string `yaml:"username,omitempty"`
+	Password string `yaml:"password,omitempty"`
+	KeyFile  string `yaml:"key_file,omitempty"`
 }
 
 // FeatureConfig is the list of collectors enabled or disabled
@@ -78,6 +87,7 @@ func Load(reader io.Reader) (*Config, error) {
 }
 
 func setDefaultValues(c *Config) {
+	c.Jumphost.Host = ""
 	c.Password = ""
 	c.LSEnabled = false
 	f := &c.Features

--- a/connector/device.go
+++ b/connector/device.go
@@ -7,8 +7,10 @@ import (
 )
 
 type Device struct {
-	Host string
-	Auth AuthMethod
+	Jumphost     string
+	JumphostAuth AuthMethod
+	Host         string
+	Auth         AuthMethod
 }
 
 // AuthMethod is the method to use to authenticate agaist the device


### PR DESCRIPTION
Introduce a new Jumphost configuration object (as requested in issue #104) that is available on global level and per device (similar to username/password). The object contains host/username/password/key_file to authenticate to device, before connecting through this device to the end device.

    jumphost:
      host: "jumphost.example.org"
      username: "operator"
      key_file: "jumphost_key"
    devices:
    ...

This patch adds some duplicate code e.g. authForJumphost and could probably be cleaned up a bit. The code also relies on the keep alive pattern of the forwarded session rather than managing its own session.

The actual jumphost connection is in `connectToDevice` where the code path is split in the jumphost and regular connection path.